### PR TITLE
This change makes it so that windows PE executable unit tests will no…

### DIFF
--- a/.github/workflows/cmake-win-llvm-cross.yml
+++ b/.github/workflows/cmake-win-llvm-cross.yml
@@ -89,6 +89,7 @@ jobs:
       run: |
        cmake -GNinja -S . -B build  \
        -DDISABLE_VERSION=TRUE \
+       -DBuildTest=TRUE \
        -DCMAKE_TOOLCHAIN_FILE=cmake_config/llvm-win-cross.cmake
 
     - name: Build
@@ -103,21 +104,8 @@ jobs:
         VER=$(cat $GITHUB_WORKSPACE/src/lib/Version/version.txt)
         echo "VERSION=$VER" >> $GITHUB_ENV
         echo "APPNAME=$APP" >> $GITHUB_ENV
-    
-    - name: Prepare Binaries for upload (Linux)
-      if: matrix.os == 'ubuntu-latest'
-      shell: bash
-      run:  |
-        mkdir ${{github.workspace}}/artifacts
-        cp build/src/lib/${{ env.APPNAME }}Core.lib ${{github.workspace}}/artifacts
-        cp build/src/cli/${{ env.APPNAME }}.exe ${{github.workspace}}/artifacts
-        
-        pushd ${{github.workspace}}
-        zip -r ${{ env.APPNAME }}-$(uname -s)-$(uname -m)-llvm-win-cross.zip artifacts
-        popd
-    
-    - name: Prepare Binaries for upload (Mac)
-      if: matrix.os == 'macOS-latest'
+
+    - name: Prepare Binaries for upload
       shell: bash
       run:  |
         mkdir ${{github.workspace}}/artifacts
@@ -128,8 +116,7 @@ jobs:
         pushd ${{github.workspace}}
         zip -r ${{ env.APPNAME }}-$(uname -s)-$(uname -m)-llvm-win-cross.zip artifacts
         popd
-
-    
+ 
     - name: 'Upload Pull Request Artifact'
       uses: actions/upload-artifact@v3
       if: startsWith(github.ref, 'refs/pull/') || startsWith(github.ref, 'refs/heads/master')
@@ -153,8 +140,10 @@ jobs:
       run: |
         md MacOS
         Expand-Archive Warf-Darwin-x86_64-llvm-win-cross.zip MacOS
+        MacOS\artifacts\Warf.exe -e "1 + 2"
         MacOS\artifacts\WarfLang_TEST.exe
         md Linux
         Expand-Archive Warf-Linux-x86_64-llvm-win-cross.zip Linux
         Linux\artifacts\Warf.exe -e "1 + 2"
+        Linux\artifacts\WarfLang_TEST.exe
     

--- a/Dockerfile.llvm-win-cross
+++ b/Dockerfile.llvm-win-cross
@@ -22,7 +22,8 @@ RUN mkdir packages \
     && cd packages \
     && ./../scripts/download_win_sysroot.sh
 
-RUN cd packages \
+RUN ls scripts \
+    && cd packages \
     && ./../scripts/vfs_overlay.sh
 
 RUN cd packages \
@@ -37,20 +38,22 @@ COPY cmake_config cmake_config
 
 RUN cmake -GNinja -S . -B winBuild  \
     -DCMAKE_BUILD_TYPE=Release \
+    -DBuildTest=TRUE \
     -DDISABLE_VERSION=TRUE \
     -DCMAKE_TOOLCHAIN_FILE=cmake_config/llvm-win-cross.cmake
 
 RUN ninja -C./winBuild
-
-# To get wine to run 32 and 64 bit binaries you have to do the install in stages
-#RUN dpkg --add-architecture i386
-#RUN apt-get update \
-#    && apt install -y \
-#    wine32
+#
+## To get wine to run 32 and 64 bit binaries you have to do the install in stages
+##RUN dpkg --add-architecture i386
+##RUN apt-get update \
+##    && apt install -y \
+##    wine32
 ENV WINEPATH="/root/project/packages/win_sysroot/MSVC/14.11.25547/lib/x64"
 ENV WINEPATH="$WINEPATH;/root/project/packages/win_sysroot/WINSDK/10.0.22621.0/lib/um/x64"
 ENV WINEPATH="$WINEPATH;/root/project/packages/win_sysroot/WINSDK/10.0.22621.0/lib/ucrt/x64"
 RUN wine cmd /C winBuild/src/cli/Warf.exe -e "5*(2+3-1)" --show_tree
+RUN wine cmd /C winBuild/test/WarfLang_TEST.exe
 
 
 

--- a/Dockerfile.llvm-win-cross
+++ b/Dockerfile.llvm-win-cross
@@ -22,8 +22,7 @@ RUN mkdir packages \
     && cd packages \
     && ./../scripts/download_win_sysroot.sh
 
-RUN ls scripts \
-    && cd packages \
+RUN cd packages \
     && ./../scripts/vfs_overlay.sh
 
 RUN cd packages \

--- a/cmake_config/llvm-win-cross.cmake
+++ b/cmake_config/llvm-win-cross.cmake
@@ -27,6 +27,7 @@ set(WIN_SDK_PATH  "win_sysroot/WINSDK/${WIN_SDK_VERSION}")
 set(WIN_MSVC_PATH "win_sysroot/MSVC/${MSVC_VERSION}")
 set(WIN_SDK_INCLUDE_PATH "${WIN_SDK_PATH}/include")
 set(WIN_SDK_LIB_PATH "${WIN_SDK_PATH}/lib")
+set(WiN_VFS_OVERLAY ${CMAKE_CURRENT_LIST_DIR}/../packages/winsdk_vfs_overlay.yaml)
 
 if(APPLE)
     include_directories(/usr/local/opt/llvm/include)
@@ -46,11 +47,32 @@ link_directories(
                  ${CMAKE_CURRENT_LIST_DIR}/../packages/${WIN_SDK_LIB_PATH}/um/x64
                  ${CMAKE_CURRENT_LIST_DIR}/../packages/${WIN_SDK_LIB_PATH}/ucrt/x64)
 
-set(GNU_UNDEF_FLAGS "-U__GNUC__ -U__gnu_linux__ -U__GNUC_MINOR__ -U__GNUC_PATCHLEVEL__ -U__GNUC_STDC_INLINE__")
-set(XCLANG_FLAGS "-Xclang -ivfsoverlay -Xclang ${CMAKE_CURRENT_LIST_DIR}/../packages/winsdk_vfs_overlay.yaml -Xclang -disable-llvm-verifier -Xclang '--dependent-lib=msvcrt' -Xclang '--dependent-lib=ucrt' -Xclang '--dependent-lib=oldnames' -Xclang '--dependent-lib=vcruntime'")
+add_compile_options(
+    # XCLANG_FLAGS
+    "SHELL:-Xclang -ivfsoverlay -Xclang ${WiN_VFS_OVERLAY}"
+    "SHELL:-Xclang --dependent-lib=oldnames"
+    "SHELL:-Xclang --dependent-lib=ucrt"
+    "SHELL:-Xclang --dependent-lib=vcruntime"
+    "SHELL:-Xclang --dependent-lib=msvcrt$<$<CONFIG:Debug>:d>"
+    "SHELL:-Xclang -disable-llvm-verifier"
+    # WARNINGS
+    -Wno-msvc-not-found
+    # GNU undefs
+    "-U__GNUC__"
+    "-U__gnu_linux__" 
+    "-U__GNUC_MINOR__" 
+    "-U__GNUC_PATCHLEVEL__" 
+    "-U__GNUC_STDC_INLINE__"
+    #Definitions
+    "-DWIN32" 
+    "-D_WIN#@"
+    "-D_MT" 
+    "-D_DLL" 
+    "-D_CRT_SECURE_NO_WARNINGS" 
+    "-D_CRT_NONSTDC_NO_DEPRECATE"
+)
+
 set(F_FLAGS "-fms-compatibility-version=19.11 -fms-extensions -fdelayed-template-parsing -fexceptions -mthread-model posix -fno-threadsafe-statics")
-set(DEF_FLAGS  "-DWIN32 -D_WIN#@ -D_MT -D_DLL -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE")
-set(WARN_FLAGS "-Wno-msvc-not-found")
-set(COMPILE_FLAGS "--target=${TARGET_TRIPLE} -nostdlib -lmsvcrt ${F_FLAGS} ${DEF_FLAGS} ${XCLANG_FLAGS} ${GNU_UNDEF_FLAGS} ${WARN_FLAGS}" )
+set(COMPILE_FLAGS "--target=${TARGET_TRIPLE} -nostdlib -lmsvcrt ${F_FLAGS}" )
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  ${COMPILE_FLAG}" CACHE STRING "" FORCE)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMPILE_FLAG}" CACHE STRING "" FORCE)

--- a/scripts/vfs_overlay.sh
+++ b/scripts/vfs_overlay.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+toLower () {
+  echo $1 | tr '[:upper:]' '[:lower:]'
+}
+
+specialCases() {
+    case $1 in
+        'bcrypt.h') echo 'Bcrypt.h';;
+        'concurrencysal.h') echo 'ConcurrencySal.h';;
+        'driverspecs.h') echo 'DriverSpecs.h';;
+        'specstrings.h') echo 'SpecStrings.h';;
+        'wlantypes.h') echo 'WlanTypes.h';;
+        *) echo $1;;
+    esac
+}
+
 # Create a VFS overlay of the Win SDK for a case insensitive file system
 echo "version: 0" > winsdk_vfs_overlay.yaml
 echo "case-sensitive: false" >> winsdk_vfs_overlay.yaml
@@ -16,7 +31,7 @@ for dir in $(find $PWD/win_sysroot/WINSDK/$WIN_SDK_VERSION/include/ -type d); do
         echo "    type: directory" >> winsdk_vfs_overlay.yaml
         echo "    contents:" >> winsdk_vfs_overlay.yaml
         for f in $files; do
-            echo "      - name: \"$(basename $f)\"" >> winsdk_vfs_overlay.yaml
+            echo "      - name: \"$(specialCases $(toLower $(basename $f)))\"" >> winsdk_vfs_overlay.yaml
             echo "        type: file" >> winsdk_vfs_overlay.yaml
             echo "        external-contents: \"$f\"" >> winsdk_vfs_overlay.yaml
         done
@@ -30,7 +45,7 @@ for dir in $(find $PWD/win_sysroot/MSVC/$MSVC_VERSION/include/ -type d); do
         echo "    type: directory" >> winsdk_vfs_overlay.yaml
         echo "    contents:" >> winsdk_vfs_overlay.yaml
         for f in $files; do
-            echo "      - name: \"$(basename $f)\"" >> winsdk_vfs_overlay.yaml
+            echo "      - name: \"$(specialCases $(toLower $(basename $f)))\"" >> winsdk_vfs_overlay.yaml
             echo "        type: file" >> winsdk_vfs_overlay.yaml
             echo "        external-contents: \"$f\"" >> winsdk_vfs_overlay.yaml
         done


### PR DESCRIPTION
…w build on Linux.

The fix was to invoke XClang via add_compile_options. The winsdk_vfs_overlay.yaml file is finally propogating. As such this change fixes #29.